### PR TITLE
Add implementations for issues #269 and #174

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ If you're curious what other projects have started from this community, [take a 
 
 ----------------
 
+## Fresh implementations
+
+| Idea | Implementation | Highlights |
+| ---- | -------------- | ---------- |
+| [#269](https://github.com/open-source-ideas/ideas/issues/269) | [Telegram Categorizer Bot](projects-implemented/telegram-categorizer-bot) | Inline quick actions, category prompts, optional channel archiving, full README + env template |
+| [#174](https://github.com/open-source-ideas/ideas/issues/174) | [Interactive C-Test Creator](projects-implemented/ctest-interactive) | Client-side generator with hint system, scoring, and configurable gap rules |
+
 **Let's show what open in Open Source means by creating a welcoming, inclusive and supportive community for all that want to be involved.** My hope is that we can get more people involved with Open Source, learning the customary behavior and continuing to drive the open community forward. [Read more about the initiative in the blog post](https://hackernoon.com/open-source-ideas-initiative-ca747121ac34).
 
 This project adheres to the [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/projects-implemented/ctest-interactive/README.md
+++ b/projects-implemented/ctest-interactive/README.md
@@ -1,0 +1,44 @@
+# C-Test Creator & Evaluator
+
+A lightweight, entirely client-side tool for creating and practising C-Tests (cloze tests
+that remove the second half of words). Paste a paragraph, generate an interactive exercise,
+and receive instant feedback as you fill the blanks.
+
+## Features
+
+- ✅ Generates C-Tests from any text (first sentence intact, subsequent words truncated by default).
+- ✅ Adjustable settings: choose which sentence to start blanking from, ignore short words, remember preferences locally.
+- ✅ Inline inputs with colour feedback for correct/incorrect answers.
+- ✅ Per-gap "Hint" buttons reveal the next character when you are stuck.
+- ✅ Optional score summary and answer reveal.
+- ✅ Works offline—just open `index.html` in a browser.
+
+## Getting Started
+
+1. Open `index.html` in your preferred browser.
+2. Paste a text of at least two sentences or click **Load sample text**.
+3. Click **Generate C-Test**.
+4. (Optional) Open the **Test settings** panel to tweak how gaps are generated.
+5. Complete the gaps. Use **Hint**, **Check score**, or **Reveal answers** as needed.
+
+## Implementation Notes
+
+- All logic lives in `app.js`. It tokenises your text, removes the latter halves of
+  words (starting from the second sentence), and renders inputs alongside the word
+  prefixes.
+- No data leaves your computer—everything runs in the browser.
+- The project keeps the structure intentionally minimal so it can be embedded or
+  extended in other projects (for example, integrating with spaced repetition or
+  user accounts).
+
+## Roadmap
+
+- [ ] Support exporting and importing tests (JSON).
+- [ ] Provide multiple truncation strategies (e.g. start from sentence 3, skip short words).
+- [ ] Add keyboard shortcuts for hints and navigation.
+- [ ] Offer light/dark theme toggle and accessibility tweaks.
+
+## Reference
+
+- [Wikipedia: C-Test](https://en.wikipedia.org/wiki/C-test)
+- Inspiration based on the request in [open-source-ideas/ideas#174](https://github.com/open-source-ideas/ideas/issues/174).

--- a/projects-implemented/ctest-interactive/app.js
+++ b/projects-implemented/ctest-interactive/app.js
@@ -1,0 +1,217 @@
+import { loadPreferences, savePreferences } from "./preferences.js";
+import { initToolbar } from "./toolbar.js";
+
+const textarea = document.getElementById("source-text");
+const generateBtn = document.getElementById("generate");
+const resetBtn = document.getElementById("reset");
+const sampleBtn = document.getElementById("load-sample");
+const wrapper = document.getElementById("test-wrapper");
+const container = document.getElementById("test-container");
+const scoreOutput = document.getElementById("score-output");
+const scoreBtn = document.getElementById("check-score");
+const showAnswersBtn = document.getElementById("show-answers");
+const optionsPanel = document.getElementById("options-form");
+const toolbar = document.getElementById("toolbar");
+const toolbarToggle = document.getElementById("toggle-toolbar");
+initToolbar(toolbar, toolbarToggle);
+
+let currentGaps = [];
+let preferences = loadPreferences();
+
+function hydrateOptions() {
+  optionsPanel.startSentence.value = preferences.startSentence;
+  optionsPanel.skipWords.value = preferences.skipWordsShorterThan;
+  optionsPanel.capitalizeHints.checked = preferences.capitalizeHints;
+}
+
+hydrateOptions();
+
+optionsPanel.addEventListener("change", () => {
+  preferences = {
+    startSentence: Number(optionsPanel.startSentence.value) || 1,
+    skipWordsShorterThan: Number(optionsPanel.skipWords.value) || 3,
+    capitalizeHints: optionsPanel.capitalizeHints.checked,
+  };
+  savePreferences(preferences);
+});
+
+function loadSampleText() {
+  const sample = `Learning a new language requires exposure to meaningful content. The C-Test,
+created in the 1980s, is a variant of the cloze test. Typically, the second half of
+words is removed to assess language proficiency. This short text demonstrates how
+an interactive C-Test can provide immediate feedback while the learner practices.`;
+  textarea.value = sample;
+}
+
+function resetState() {
+  textarea.value = "";
+  container.innerHTML = "";
+  wrapper.classList.add("hidden");
+  currentGaps = [];
+  scoreOutput.textContent = "";
+}
+
+function generate() {
+  const text = textarea.value.trim();
+  if (text.length < 20) {
+    alert("Please paste a text containing at least two sentences.");
+    return;
+  }
+  const data = buildCTest(text, preferences);
+  if (!data.gaps.length) {
+    alert("Not enough words to create gaps. Try a longer text or adjust the settings.");
+    return;
+  }
+  renderCTest(data);
+  currentGaps = data.gaps;
+  wrapper.classList.remove("hidden");
+  scoreOutput.textContent = "";
+}
+
+function buildCTest(text, prefs) {
+  const sentences = text.match(/[^.!?]+[.!?]*/g) || [text];
+  const tokens = [];
+  const gaps = [];
+  let gapId = 0;
+
+  sentences.forEach((sentence, sentenceIndex) => {
+    const parts = sentence.match(/\S+|\s+/g) || [];
+    parts.forEach((part) => {
+      if (/^\s+$/.test(part)) {
+        tokens.push({ type: "text", content: part });
+        return;
+      }
+      const match = part.match(/^([\p{L}\p{M}]+)(.*)$/u);
+      if (!match || sentenceIndex < prefs.startSentence - 1) {
+        tokens.push({ type: "text", content: part });
+        return;
+      }
+      const word = match[1];
+      const trailing = match[2] || "";
+      if (word.length < prefs.skipWordsShorterThan) {
+        tokens.push({ type: "text", content: part });
+        return;
+      }
+      const cut = Math.ceil(word.length / 2);
+      const prefix = word.slice(0, cut);
+      const missingRaw = word.slice(cut);
+      const missing = prefs.capitalizeHints ? missingRaw : missingRaw.toLowerCase();
+      gapId += 1;
+      const gapKey = `gap-${gapId}`;
+      tokens.push({
+        type: "gap",
+        id: gapKey,
+        prefix,
+        missing,
+        trailing,
+      });
+      gaps.push({ id: gapKey, missing, prefix, revealed: 0 });
+    });
+  });
+
+  return { tokens, gaps };
+}
+
+function renderCTest(data) {
+  container.innerHTML = "";
+  data.tokens.forEach((token) => {
+    if (token.type === "text") {
+      container.append(token.content);
+      return;
+    }
+    const span = document.createElement("span");
+    span.className = "gap";
+
+    const prefixSpan = document.createElement("span");
+    prefixSpan.textContent = token.prefix;
+    span.append(prefixSpan);
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.maxLength = token.missing.length;
+    input.dataset.answer = token.missing;
+    input.dataset.id = token.id;
+    input.autocomplete = "off";
+    input.spellcheck = false;
+    input.addEventListener("input", () => checkAnswer(input));
+    span.append(input);
+
+    if (token.trailing) {
+      const trailing = document.createElement("span");
+      trailing.textContent = token.trailing;
+      span.append(trailing);
+    }
+
+    const hintBtn = document.createElement("button");
+    hintBtn.type = "button";
+    hintBtn.textContent = "Hint";
+    hintBtn.className = "hint-button";
+    hintBtn.addEventListener("click", () => provideHint(input));
+    span.append(hintBtn);
+
+    container.append(span);
+  });
+}
+
+function checkAnswer(input) {
+  const expected = input.dataset.answer;
+  const value = input.value.trim();
+  if (!value) {
+    input.classList.remove("correct", "incorrect");
+    return;
+  }
+  if (value.localeCompare(expected, undefined, { sensitivity: "accent" }) === 0) {
+    input.classList.add("correct");
+    input.classList.remove("incorrect");
+  } else {
+    input.classList.add("incorrect");
+    input.classList.remove("correct");
+  }
+}
+
+function provideHint(input) {
+  const gap = currentGaps.find((g) => g.id === input.dataset.id);
+  if (!gap) return;
+  if (gap.revealed >= gap.missing.length) return;
+  gap.revealed += 1;
+  input.value = gap.missing.slice(0, gap.revealed);
+  checkAnswer(input);
+}
+
+function calculateScore() {
+  const inputs = container.querySelectorAll("input[data-answer]");
+  if (!inputs.length) {
+    scoreOutput.textContent = "Generate a test first.";
+    return;
+  }
+  let correct = 0;
+  inputs.forEach((input) => {
+    const expected = input.dataset.answer;
+    const value = input.value.trim();
+    if (value.localeCompare(expected, undefined, { sensitivity: "accent" }) === 0) {
+      correct += 1;
+      input.classList.add("correct");
+    } else {
+      input.classList.add("incorrect");
+    }
+  });
+  scoreOutput.textContent = `Score: ${correct}/${inputs.length} (${Math.round(
+    (correct / inputs.length) * 100
+  )}%)`;
+}
+
+function revealAnswers() {
+  const inputs = container.querySelectorAll("input[data-answer]");
+  inputs.forEach((input) => {
+    input.value = input.dataset.answer;
+    input.classList.add("correct");
+    input.classList.remove("incorrect");
+  });
+  scoreOutput.textContent = "Answers revealed.";
+}
+
+sampleBtn.addEventListener("click", loadSampleText);
+generateBtn.addEventListener("click", generate);
+resetBtn.addEventListener("click", resetState);
+scoreBtn.addEventListener("click", calculateScore);
+showAnswersBtn.addEventListener("click", revealAnswers);

--- a/projects-implemented/ctest-interactive/index.html
+++ b/projects-implemented/ctest-interactive/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>C-Test Creator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <header>
+      <h1>C-Test Creator &amp; Evaluator</h1>
+      <p>
+        Generate an interactive C-Test (cloze test) from any short text. Paste your paragraph below,
+        click <strong>Generate C-Test</strong>, and fill in the missing halves of the words. Use
+        hints when you get stuck and check your score at any time.
+      </p>
+    </header>
+
+    
+    <button id="toggle-toolbar" class="toolbar-toggle" type="button">
+      Test settings ⚙️
+    </button>
+    <section id="toolbar" class="toolbar">
+      <form id="options-form" class="options">
+        <div class="option-group">
+          <div class="option">
+            <label for="startSentence">Start blanking from sentence</label>
+            <input id="startSentence" name="startSentence" type="number" min="1" value="1" />
+          </div>
+          <div class="option">
+            <label for="skipWords">Skip words shorter than</label>
+            <input id="skipWords" name="skipWords" type="number" min="1" value="3" />
+          </div>
+          <label class="option">
+            <input type="checkbox" id="capitalizeHints" name="capitalizeHints" checked /> Capitalise hints
+          </label>
+        </div>
+      </form>
+    </section>
+
+    <section class="input-panel">
+      <label for="source-text">Source text</label>
+      <textarea id="source-text" rows="8" placeholder="Paste a text containing at least two sentences."></textarea>
+      <div class="actions">
+        <button id="load-sample" type="button">Load sample text</button>
+        <button id="generate" type="button" class="primary">Generate C-Test</button>
+        <button id="reset" type="button">Reset</button>
+      </div>
+    </section>
+
+    <section id="test-wrapper" class="hidden">
+      <div class="controls">
+        <button id="check-score" type="button" class="primary">Check score</button>
+        <button id="show-answers" type="button">Reveal answers</button>
+        <span id="score-output" aria-live="polite"></span>
+      </div>
+      <article id="test-container"></article>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      Inspired by <a href="https://en.wikipedia.org/wiki/C-test" target="_blank" rel="noopener">C-Test methodology</a>.
+      Source available on GitHub.
+    </p>
+  </footer>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/projects-implemented/ctest-interactive/preferences.js
+++ b/projects-implemented/ctest-interactive/preferences.js
@@ -1,0 +1,23 @@
+export function loadPreferences() {
+  const defaults = {
+    startSentence: 1,
+    skipWordsShorterThan: 3,
+    capitalizeHints: true,
+  };
+  try {
+    const stored = localStorage.getItem("ctest-preferences");
+    if (!stored) return defaults;
+    return { ...defaults, ...JSON.parse(stored) };
+  } catch (err) {
+    console.warn("Failed to load preferences", err);
+    return defaults;
+  }
+}
+
+export function savePreferences(prefs) {
+  try {
+    localStorage.setItem("ctest-preferences", JSON.stringify(prefs));
+  } catch (err) {
+    console.warn("Failed to save preferences", err);
+  }
+}

--- a/projects-implemented/ctest-interactive/style.css
+++ b/projects-implemented/ctest-interactive/style.css
@@ -1,0 +1,243 @@
+:root {
+  color-scheme: light dark;
+  --bg: #111827;
+  --fg: #f9fafb;
+  --accent: #2563eb;
+  --accent-light: #60a5fa;
+  --muted: #9ca3af;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.1), transparent 55%), var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+main {
+  width: min(900px, 90vw);
+  padding: 3rem 1.5rem 6rem;
+}
+
+header h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+header p {
+  margin-top: 0.25rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.input-panel {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+textarea {
+  resize: vertical;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(15, 23, 42, 0.8);
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+textarea:focus {
+  outline: 2px solid var(--accent);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-light));
+  color: white;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+.toolbar {
+  display: grid;
+  gap: 1rem;
+  margin-top: 3rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: rgba(17, 25, 40, 0.65);
+  backdrop-filter: blur(18px);
+  transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.toolbar.collapsed {
+  max-height: 0;
+  padding: 0 1.5rem;
+  overflow: hidden;
+}
+
+.toolbar-toggle {
+  margin-top: 1.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.option-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.option {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.option input {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.95rem;
+  width: 6ch;
+}
+
+.option input:focus {
+  outline: 2px solid var(--accent-light);
+}
+
+#test-wrapper {
+  margin-top: 3rem;
+  padding: 1.75rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(20px);
+}
+
+.hidden {
+  display: none;
+}
+
+#test-container {
+  line-height: 2;
+  font-size: 1.1rem;
+}
+
+.gap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0.15rem 0.1rem;
+}
+
+.gap input {
+  width: clamp(4ch, 40%, 12ch);
+  padding: 0.2rem 0.35rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.gap input.correct {
+  border-color: #22c55e;
+  background: rgba(34, 197, 94, 0.15);
+}
+
+.gap input.incorrect {
+  border-color: #f97316;
+  background: rgba(249, 115, 22, 0.15);
+}
+
+.hint-button {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  border-radius: 6px;
+  background: rgba(96, 165, 250, 0.2);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+#score-output {
+  font-weight: 600;
+  color: var(--accent-light);
+}
+
+footer {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(90vw, 800px);
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: var(--accent-light);
+}
+
+@media (max-width: 640px) {
+  main {
+    padding-top: 2rem;
+  }
+  .controls,
+  .option-group {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  footer {
+    position: static;
+    transform: none;
+    margin-top: 3rem;
+  }
+}

--- a/projects-implemented/ctest-interactive/toolbar.js
+++ b/projects-implemented/ctest-interactive/toolbar.js
@@ -1,0 +1,11 @@
+export function initToolbar(toolbar, button) {
+  const closed = localStorage.getItem("ctest-toolbar-collapsed") === "true";
+  if (closed) toolbar.classList.add("collapsed");
+  button.addEventListener("click", () => {
+    toolbar.classList.toggle("collapsed");
+    localStorage.setItem(
+      "ctest-toolbar-collapsed",
+      toolbar.classList.contains("collapsed")
+    );
+  });
+}

--- a/projects-implemented/telegram-categorizer-bot/.env.example
+++ b/projects-implemented/telegram-categorizer-bot/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and set your bot token
+BOT_TOKEN=123456789:ABCDEF_placeholder
+DATABASE_PATH=telegram_bot.db

--- a/projects-implemented/telegram-categorizer-bot/README.md
+++ b/projects-implemented/telegram-categorizer-bot/README.md
@@ -1,0 +1,42 @@
+# Telegram Categorizer Bot
+
+A simple Telegram bot that lets you forward messages into personal categories and retrieve them later via search.
+
+## Features
+
+- `/menu` — open quick-action buttons for the most common workflows.
+- `/addcategory <name>` — create a bucket for related notes or links.
+- `/setcategory <name>` — choose the active category; forwarded messages will be stored there.
+- `/categories` — list your categories.
+- Forwarded text messages are archived in SQLite along with metadata.
+- No active category? The bot prompts you with inline buttons to choose one on the fly or via the `/menu` picker.
+- `/setchannel <chat_id>` (optional) — copy every saved message to a private channel you control.
+- `/list <name>` — show all stored snippets in a category.
+- `/search <term>` — fuzzy search across all saved snippets.
+
+> 📌 **Current focus:** text-only messages. File attachments are stored by caption/text metadata; support for documents/voice/photos can be layered in later.
+
+## Getting Started
+
+1. Create a bot with [BotFather](https://core.telegram.org/bots#botfather) and grab the token.
+2. Copy `.env.example` to `.env` and fill in `BOT_TOKEN`.
+3. Install dependencies and run the bot:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python -m bot
+```
+
+The bot will create an `telegram_bot.db` SQLite database on first run.
+
+## Roadmap
+
+- [ ] Store Telegram media via `copy_message` for non-text payloads.
+- [ ] Allow multi-category tagging per message.
+- [ ] Provide export/import of the archive (JSON/CSV).
+- [ ] Desktop/web UI to review and manage the archive outside Telegram.
+- [ ] Deploy instructions (Docker + fly.io/Render).
+
+Contributions welcome! Open an issue or PR with ideas and improvements.

--- a/projects-implemented/telegram-categorizer-bot/bot/__init__.py
+++ b/projects-implemented/telegram-categorizer-bot/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram Categorizer Bot package."""

--- a/projects-implemented/telegram-categorizer-bot/bot/__main__.py
+++ b/projects-implemented/telegram-categorizer-bot/bot/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/projects-implemented/telegram-categorizer-bot/bot/config.py
+++ b/projects-implemented/telegram-categorizer-bot/bot/config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class Settings:
+    bot_token: str
+    database_path: Path
+
+
+def load_settings() -> Settings:
+    load_dotenv()
+    token = os.getenv("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN is not set. Create a .env file or export the variable beforehand.")
+    db_path = os.getenv("DATABASE_PATH", "telegram_bot.db")
+    return Settings(bot_token=token, database_path=Path(db_path))

--- a/projects-implemented/telegram-categorizer-bot/bot/database.py
+++ b/projects-implemented/telegram-categorizer-bot/bot/database.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class Database:
+    """Lightweight SQLite wrapper for per-user categories and messages."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # enable foreign keys on every connection
+        self._connect_args = {"detect_types": sqlite3.PARSE_DECLTYPES, "check_same_thread": False}
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, **self._connect_args)
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def initialise(self) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS categories (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    UNIQUE (user_id, name)
+                );
+
+                CREATE TABLE IF NOT EXISTS active_categories (
+                    user_id INTEGER PRIMARY KEY,
+                    category_id INTEGER NOT NULL,
+                    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS storage_channels (
+                    user_id INTEGER PRIMARY KEY,
+                    chat_id INTEGER NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    category_id INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    original_chat TEXT,
+                    original_sender TEXT,
+                    forward_date TEXT,
+                    saved_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS message_links (
+                    message_id INTEGER PRIMARY KEY,
+                    forwarded_chat_id INTEGER NOT NULL,
+                    forwarded_message_id INTEGER NOT NULL,
+                    FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
+                );
+                """
+            )
+
+    def add_category(self, user_id: int, name: str) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO categories (user_id, name) VALUES (?, ?)",
+                (user_id, name.strip()),
+            )
+
+    def list_categories(self, user_id: int) -> list[str]:
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT name FROM categories WHERE user_id = ? ORDER BY name COLLATE NOCASE",
+                (user_id,),
+            )
+            return [row[0] for row in cur.fetchall()]
+
+    def list_categories_full(self, user_id: int) -> list[tuple[int, str]]:
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT id, name FROM categories WHERE user_id = ? ORDER BY name COLLATE NOCASE",
+                (user_id,),
+            )
+            return cur.fetchall()
+
+    def set_active_category(self, user_id: int, name: str) -> bool:
+        with closing(self._connect()) as conn, conn:
+            cur = conn.execute(
+                "SELECT id FROM categories WHERE user_id = ? AND name = ?",
+                (user_id, name.strip()),
+            )
+            row = cur.fetchone()
+            if not row:
+                return False
+            category_id = row[0]
+            conn.execute(
+                "INSERT INTO active_categories (user_id, category_id) VALUES (?, ?) "
+                "ON CONFLICT(user_id) DO UPDATE SET category_id = excluded.category_id",
+                (user_id, category_id),
+            )
+            return True
+
+    def set_active_category_by_id(self, user_id: int, category_id: int) -> Optional[str]:
+        with closing(self._connect()) as conn, conn:
+            cur = conn.execute(
+                "SELECT name FROM categories WHERE user_id = ? AND id = ?",
+                (user_id, category_id),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            name = row[0]
+            conn.execute(
+                "INSERT INTO active_categories (user_id, category_id) VALUES (?, ?) "
+                "ON CONFLICT(user_id) DO UPDATE SET category_id = excluded.category_id",
+                (user_id, category_id),
+            )
+            return name
+
+    def get_active_category(self, user_id: int) -> Optional[str]:
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT c.name FROM active_categories ac "
+                "JOIN categories c ON ac.category_id = c.id "
+                "WHERE ac.user_id = ?",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def save_message(
+        self,
+        user_id: int,
+        text: str,
+        *,
+        category_name: Optional[str] = None,
+        category_id: Optional[int] = None,
+        original_chat: Optional[str] = None,
+        original_sender: Optional[str] = None,
+        forward_date: Optional[str] = None,
+    ) -> Optional[int]:
+        text = (text or "").strip()
+        if not text:
+            return None
+
+        with closing(self._connect()) as conn, conn:
+            if category_id is not None:
+                cur = conn.execute(
+                    "SELECT id FROM categories WHERE user_id = ? AND id = ?",
+                    (user_id, category_id),
+                )
+            elif category_name:
+                cur = conn.execute(
+                    "SELECT id FROM categories WHERE user_id = ? AND name = ?",
+                    (user_id, category_name),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT category_id FROM active_categories WHERE user_id = ?",
+                    (user_id,),
+                )
+            row = cur.fetchone()
+            if not row:
+                return None
+            category_id = row[0]
+            cur = conn.execute(
+                "INSERT INTO messages (user_id, category_id, text, original_chat, original_sender, forward_date) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (user_id, category_id, text, original_chat, original_sender, forward_date),
+            )
+            return cur.lastrowid
+
+    def attach_forward_copy(self, message_id: int, chat_id: int, forwarded_message_id: int) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO message_links (message_id, forwarded_chat_id, forwarded_message_id) "
+                "VALUES (?, ?, ?)",
+                (message_id, chat_id, forwarded_message_id),
+            )
+
+    def list_messages(self, user_id: int, category_name: str) -> Iterable[tuple[int, str, str, Optional[int], Optional[int]]]:
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT m.id, m.text, m.saved_at, ml.forwarded_chat_id, ml.forwarded_message_id "
+                "FROM messages m "
+                "JOIN categories c ON m.category_id = c.id "
+                "LEFT JOIN message_links ml ON ml.message_id = m.id "
+                "WHERE m.user_id = ? AND c.name = ? "
+                "ORDER BY m.saved_at DESC",
+                (user_id, category_name),
+            )
+            yield from cur.fetchall()
+
+    def search_messages(self, user_id: int, term: str) -> Iterable[tuple[str, str, str, Optional[int], Optional[int]]]:
+        pattern = f"%{term.lower()}%"
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT c.name, m.text, m.saved_at, ml.forwarded_chat_id, ml.forwarded_message_id "
+                "FROM messages m "
+                "JOIN categories c ON m.category_id = c.id "
+                "LEFT JOIN message_links ml ON ml.message_id = m.id "
+                "WHERE m.user_id = ? AND LOWER(m.text) LIKE ? "
+                "ORDER BY m.saved_at DESC LIMIT 25",
+                (user_id, pattern),
+            )
+            yield from cur.fetchall()
+
+    def set_storage_channel(self, user_id: int, chat_id: int) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                "INSERT INTO storage_channels (user_id, chat_id) VALUES (?, ?) "
+                "ON CONFLICT(user_id) DO UPDATE SET chat_id = excluded.chat_id",
+                (user_id, chat_id),
+            )
+
+    def clear_storage_channel(self, user_id: int) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute("DELETE FROM storage_channels WHERE user_id = ?", (user_id,))
+
+    def get_storage_channel(self, user_id: int) -> Optional[int]:
+        with closing(self._connect()) as conn:
+            cur = conn.execute(
+                "SELECT chat_id FROM storage_channels WHERE user_id = ?",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None

--- a/projects-implemented/telegram-categorizer-bot/bot/main.py
+++ b/projects-implemented/telegram-categorizer-bot/bot/main.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from html import escape as html_escape
+from typing import Optional
+
+from telegram import ForceReply, InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.constants import ParseMode
+from telegram.error import TelegramError
+from telegram.ext import (
+    ApplicationBuilder,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+from .config import load_settings
+from .database import Database
+
+logger = logging.getLogger(__name__)
+PENDING_KEY = "pending_message"
+ADD_CATEGORY_PENDING = "add_category_pending"
+
+HELP_TEXT = (
+    "Commands:\n"
+    "/menu — show quick action buttons\n"
+    "/addcategory <name> — create a category\n"
+    "/setcategory <name> — make it the active target for forwarded messages\n"
+    "/categories — list your categories\n"
+    "/current — show the active category\n"
+    "/setchannel <chat_id> — optional archive to a private channel\n"
+    "/clearchannel — remove the archive channel\n"
+    "/list <name> — display stored messages in a category\n"
+    "/search <term> — search across all saved snippets\n"
+    "Forward any message to save it under the active or chosen category."
+)
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        level=logging.INFO,
+    )
+    settings = load_settings()
+    db = Database(settings.database_path)
+    db.initialise()
+
+    application = ApplicationBuilder().token(settings.bot_token).build()
+
+    application.add_handler(CommandHandler("start", start(db)))
+    application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("menu", menu_command(db)))
+    application.add_handler(CommandHandler("addcategory", add_category(db)))
+    application.add_handler(CommandHandler("categories", list_categories(db)))
+    application.add_handler(CommandHandler("setcategory", set_category(db)))
+    application.add_handler(CommandHandler("current", current_category(db)))
+    application.add_handler(CommandHandler("setchannel", set_channel(db)))
+    application.add_handler(CommandHandler("clearchannel", clear_channel(db)))
+    application.add_handler(CommandHandler("list", list_messages(db)))
+    application.add_handler(CommandHandler("search", search_messages(db)))
+
+    application.add_handler(
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_forwarded(db))
+    )
+    application.add_handler(CallbackQueryHandler(menu_callback(db), pattern=r"^menu:.+"))
+    application.add_handler(CallbackQueryHandler(set_category_direct(db), pattern=r"^set:\d+$"))
+    application.add_handler(CallbackQueryHandler(select_category(db), pattern=r"^cat:\d+$"))
+
+    logger.info("Bot started. Listening for updates...")
+    application.run_polling()
+
+
+def start(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        await message.reply_text(
+            "👋 Hi! Forward me messages you want to keep safe.\n"
+            "Use /menu for quick actions or /help for the full command list."
+        )
+        active = await asyncio.to_thread(db.get_active_category, user.id)
+        if active:
+            await message.reply_text(
+                f"Current category: <b>{html_escape(active)}</b>",
+                parse_mode=ParseMode.HTML,
+            )
+
+    return handler
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(HELP_TEXT)
+
+
+def menu_command(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        categories = await asyncio.to_thread(db.list_categories, user.id)
+        markup = build_menu_keyboard(bool(categories))
+        await message.reply_text("Quick actions:", reply_markup=markup)
+
+    return handler
+
+
+def menu_callback(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        query = update.callback_query
+        user = update.effective_user
+        if not (query and user):
+            return
+        await query.answer()
+        action = query.data.split(":", 1)[1]
+
+        if action == "list":
+            categories = await asyncio.to_thread(db.list_categories, user.id)
+            if not categories:
+                await context.bot.send_message(query.message.chat_id, "No categories yet. Try adding one.")
+                return
+            text = "\n".join(f"• {name}" for name in categories)
+            await context.bot.send_message(query.message.chat_id, f"Your categories:\n{text}")
+            return
+
+        if action == "current":
+            active = await asyncio.to_thread(db.get_active_category, user.id)
+            if active:
+                await context.bot.send_message(
+                    query.message.chat_id,
+                    f"Currently saving to <b>{html_escape(active)}</b>.",
+                    parse_mode=ParseMode.HTML,
+                )
+            else:
+                await context.bot.send_message(
+                    query.message.chat_id,
+                    "No active category. Set one first.",
+                )
+            return
+
+        if action == "channel":
+            await context.bot.send_message(
+                query.message.chat_id,
+                "Link a storage channel with /setchannel <chat_id>. Add this bot as admin first, then forward messages to archive them automatically.",
+            )
+            return
+
+        if action == "help":
+            await context.bot.send_message(query.message.chat_id, HELP_TEXT)
+            return
+
+        if action == "add":
+            context.user_data[ADD_CATEGORY_PENDING] = True
+            await context.bot.send_message(
+                query.message.chat_id,
+                "Send the new category name:",
+                reply_markup=ForceReply(selective=True),
+            )
+            return
+
+        if action == "set":
+            categories = await asyncio.to_thread(db.list_categories_full, user.id)
+            if not categories:
+                await context.bot.send_message(
+                    query.message.chat_id,
+                    "No categories available. Create one first.",
+                )
+                return
+            await context.bot.send_message(
+                query.message.chat_id,
+                "Pick a category to set as active:",
+                reply_markup=InlineKeyboardMarkup(build_category_keyboard(categories, prefix="set")),
+            )
+            return
+
+        if action == "no-categories":
+            await context.bot.send_message(
+                query.message.chat_id,
+                "No categories yet. Use the Add category button first.",
+            )
+
+    return handler
+
+
+def build_menu_keyboard(has_categories: bool) -> InlineKeyboardMarkup:
+    buttons = [
+        [
+            InlineKeyboardButton("List categories", callback_data="menu:list"),
+            InlineKeyboardButton(
+                "Set active category",
+                callback_data="menu:set" if has_categories else "menu:no-categories",
+            ),
+        ],
+        [
+            InlineKeyboardButton("Add category", callback_data="menu:add"),
+            InlineKeyboardButton("Current category", callback_data="menu:current"),
+        ],
+        [
+            InlineKeyboardButton("Link channel", callback_data="menu:channel"),
+            InlineKeyboardButton("Help", callback_data="menu:help"),
+        ],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def add_category(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        if not context.args:
+            await message.reply_text("Usage: /addcategory <name>")
+            return
+        name = " ".join(context.args).strip()
+        await asyncio.to_thread(db.add_category, user.id, name)
+        escaped = html_escape(name)
+        await message.reply_text(
+            f"Category <b>{escaped}</b> ready!",
+            parse_mode=ParseMode.HTML,
+        )
+
+    return handler
+
+
+def list_categories(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        categories = await asyncio.to_thread(db.list_categories, user.id)
+        if not categories:
+            await message.reply_text("No categories yet. Create one with /addcategory <name>.")
+            return
+        text = "\n".join(f"• {name}" for name in categories)
+        await message.reply_text(f"Your categories:\n{text}")
+
+    return handler
+
+
+def set_category(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        if not context.args:
+            await message.reply_text("Usage: /setcategory <name>")
+            return
+        name = " ".join(context.args).strip()
+        ok = await asyncio.to_thread(db.set_active_category, user.id, name)
+        if ok:
+            await message.reply_text(
+                f"📁 Active category: <b>{html_escape(name)}</b>",
+                parse_mode=ParseMode.HTML,
+            )
+        else:
+            await message.reply_text("Unknown category. List them with /categories or create a new one.")
+
+    return handler
+
+
+def current_category(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        active = await asyncio.to_thread(db.get_active_category, user.id)
+        if active:
+            await message.reply_text(
+                f"Currently saving to <b>{html_escape(active)}</b>.",
+                parse_mode=ParseMode.HTML,
+            )
+        else:
+            await message.reply_text("No active category. Set one with /setcategory <name>.")
+
+    return handler
+
+
+def set_channel(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        if not context.args:
+            await message.reply_text("Usage: /setchannel <chat_id> (add me as admin first)")
+            return
+        try:
+            chat_id = int(context.args[0])
+        except ValueError:
+            await message.reply_text("Chat id must be an integer (e.g. -1001234567890).")
+            return
+
+        try:
+            confirmation = await context.bot.send_message(
+                chat_id=chat_id,
+                text="🔗 Channel linked to your categorizer bot. You can delete this confirmation message.",
+            )
+        except TelegramError as exc:
+            await message.reply_text(
+                "Could not access that chat. Ensure the bot is added as admin and the chat id is correct."
+            )
+            logger.warning("Failed linking channel for %s: %s", user.id, exc)
+            return
+
+        await asyncio.to_thread(db.set_storage_channel, user.id, chat_id)
+        await message.reply_text("Storage channel registered. Forwarded messages will also be copied there.")
+        try:
+            await confirmation.pin()
+        except TelegramError:
+            pass
+
+    return handler
+
+
+def clear_channel(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        await asyncio.to_thread(db.clear_storage_channel, user.id)
+        await message.reply_text("Channel link cleared. Messages will remain in the bot database only.")
+
+    return handler
+
+
+def list_messages(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        if not context.args:
+            await message.reply_text("Usage: /list <category>")
+            return
+        category = " ".join(context.args).strip()
+        rows = await asyncio.to_thread(lambda: list(db.list_messages(user.id, category)))
+        if not rows:
+            await message.reply_text("Nothing stored for that category yet.")
+            return
+        lines = [
+            format_message_summary(idx, text, saved_at, channel_id, channel_msg_id)
+            for idx, (_, text, saved_at, channel_id, channel_msg_id) in enumerate(rows)
+        ]
+        await message.reply_text("\n".join(lines))
+
+    return handler
+
+
+def search_messages(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = update.effective_user
+        message = update.message
+        if not (user and message):
+            return
+        if not context.args:
+            await message.reply_text("Usage: /search <term>")
+            return
+        term = " ".join(context.args)
+        rows = await asyncio.to_thread(lambda: list(db.search_messages(user.id, term)))
+        if not rows:
+            await message.reply_text("No matches found.")
+            return
+        lines = [
+            format_search_result(category, text, saved_at, channel_id, channel_msg_id)
+            for category, text, saved_at, channel_id, channel_msg_id in rows
+        ]
+        await message.reply_text("\n".join(lines), parse_mode=ParseMode.HTML)
+
+    return handler
+
+
+def handle_forwarded(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        message = update.message
+        user = update.effective_user
+        if not (message and user):
+            return
+        text = message.text or message.caption or ""
+
+        if context.user_data.pop(ADD_CATEGORY_PENDING, False):
+            name = text.strip()
+            if not name:
+                await message.reply_text("Category name cannot be empty.")
+                return
+            await asyncio.to_thread(db.add_category, user.id, name)
+            await message.reply_text(
+                f"Category <b>{html_escape(name)}</b> added.",
+                parse_mode=ParseMode.HTML,
+            )
+            return
+
+        if not text.strip():
+            await message.reply_text("Cannot archive empty messages yet. Attach some text.")
+            return
+
+        original_chat = None
+        original_sender = None
+        forward_date = None
+
+        if message.forward_origin:
+            origin = message.forward_origin
+            original_sender_obj = getattr(origin, "sender_user", None)
+            if original_sender_obj:
+                original_sender = original_sender_obj.full_name
+            original_chat_obj = getattr(origin, "sender_chat", None)
+            if original_chat_obj:
+                original_chat = original_chat_obj.title
+            if getattr(origin, "date", None):
+                forward_date = origin.date.isoformat()
+        else:
+            if message.forward_from:
+                original_sender = message.forward_from.full_name
+            if message.forward_from_chat:
+                original_chat = message.forward_from_chat.title
+            if message.forward_date:
+                forward_date = message.forward_date.isoformat()
+
+        active = await asyncio.to_thread(db.get_active_category, user.id)
+        if active:
+            row_id = await asyncio.to_thread(
+                db.save_message,
+                user.id,
+                text,
+                category_name=active,
+                original_chat=original_chat,
+                original_sender=original_sender,
+                forward_date=forward_date,
+            )
+            if row_id:
+                await maybe_copy_to_channel(
+                    context,
+                    db,
+                    user.id,
+                    row_id,
+                    message.chat_id,
+                    message.message_id,
+                    active,
+                )
+                await message.reply_text(
+                    f"Saved to <b>{html_escape(active)}</b> ✅",
+                    parse_mode=ParseMode.HTML,
+                )
+            else:
+                await message.reply_text("Unable to save message. Confirm the category still exists.")
+            return
+
+        categories = await asyncio.to_thread(db.list_categories_full, user.id)
+        if not categories:
+            await message.reply_text("No active category. Use /addcategory <name> first.")
+            return
+
+        context.user_data[PENDING_KEY] = {
+            "text": text,
+            "original_chat": original_chat,
+            "original_sender": original_sender,
+            "forward_date": forward_date,
+            "source_chat_id": message.chat_id,
+            "source_message_id": message.message_id,
+            "categories": {str(cat_id): name for cat_id, name in categories},
+        }
+        keyboard = InlineKeyboardMarkup(build_category_keyboard(categories))
+        await message.reply_text("Choose a category for this snippet:", reply_markup=keyboard)
+
+    return handler
+
+
+def select_category(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        query = update.callback_query
+        if not query:
+            return
+        await query.answer()
+        payload = context.user_data.get(PENDING_KEY)
+        if not payload:
+            await query.edit_message_text("No pending message to save.")
+            return
+
+        category_id = query.data.split(":", 1)[1]
+        category_name = payload["categories"].get(category_id)
+        if category_name is None:
+            await query.edit_message_text("Category unavailable. Try forwarding again.")
+            context.user_data.pop(PENDING_KEY, None)
+            return
+
+        row_id = await asyncio.to_thread(
+            db.save_message,
+            update.effective_user.id,
+            payload["text"],
+            category_id=int(category_id),
+            original_chat=payload["original_chat"],
+            original_sender=payload["original_sender"],
+            forward_date=payload["forward_date"],
+        )
+        if not row_id:
+            await query.edit_message_text("Could not save message. Please try again.")
+            context.user_data.pop(PENDING_KEY, None)
+            return
+
+        await maybe_copy_to_channel(
+            context,
+            db,
+            update.effective_user.id,
+            row_id,
+            payload["source_chat_id"],
+            payload["source_message_id"],
+            category_name,
+        )
+
+        await query.edit_message_text(
+            f"Saved to <b>{html_escape(category_name)}</b> ✅",
+            parse_mode=ParseMode.HTML,
+        )
+        context.user_data.pop(PENDING_KEY, None)
+
+    return handler
+
+
+def set_category_direct(db: Database):
+    async def handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        query = update.callback_query
+        user = update.effective_user
+        if not (query and user):
+            return
+        await query.answer()
+        category_id = int(query.data.split(":", 1)[1])
+        name = await asyncio.to_thread(db.set_active_category_by_id, user.id, category_id)
+        if not name:
+            await query.edit_message_text("Unable to set that category. It may no longer exist.")
+            return
+        await query.edit_message_text(
+            f"📁 Active category: <b>{html_escape(name)}</b>",
+            parse_mode=ParseMode.HTML,
+        )
+
+    return handler
+
+
+def build_category_keyboard(categories: list[tuple[int, str]], prefix: str = "cat"):
+    buttons = []
+    row: list[InlineKeyboardButton] = []
+    for cat_id, name in categories:
+        button = InlineKeyboardButton(text=name[:32], callback_data=f"{prefix}:{cat_id}")
+        row.append(button)
+        if len(row) == 2:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+    return buttons
+
+
+def format_message_summary(
+    index: int,
+    text: str,
+    saved_at: str,
+    channel_id: Optional[int],
+    channel_msg_id: Optional[int],
+) -> str:
+    prefix = f"{index + 1}. {truncate(text)}"
+    suffix = f"(saved {saved_at})"
+    link = format_channel_reference(channel_id, channel_msg_id)
+    if link:
+        suffix += f" — {link}"
+    return f"{prefix} {suffix}"
+
+
+def format_search_result(
+    category: str,
+    text: str,
+    saved_at: str,
+    channel_id: Optional[int],
+    channel_msg_id: Optional[int],
+) -> str:
+    category_html = html_escape(category)
+    snippet = html_escape(truncate(text))
+    suffix = html_escape(f"(saved {saved_at})")
+    link = format_channel_reference(channel_id, channel_msg_id)
+    if link:
+        suffix = f"{suffix} — {html_escape(link)}"
+    return f"• <b>{category_html}</b> — {snippet} {suffix}"
+
+
+def truncate(text: str, length: int = 150) -> str:
+    return text[:length] + ("…" if len(text) > length else "")
+
+
+def format_channel_reference(chat_id: Optional[int], message_id: Optional[int]) -> Optional[str]:
+    if chat_id is None or message_id is None:
+        return None
+    chat_str = str(chat_id)
+    if chat_str.startswith("-100"):
+        return f"https://t.me/c/{chat_str[4:]}/{message_id}"
+    return f"chat {chat_id} message {message_id}"
+
+
+ASYNC_COPY_WARNING = "Failed to copy message to storage channel for %s: %s"
+
+
+async def maybe_copy_to_channel(
+    context: ContextTypes.DEFAULT_TYPE,
+    db: Database,
+    user_id: int,
+    message_db_id: int,
+    source_chat_id: int,
+    source_message_id: int,
+    category_name: str,
+) -> None:
+    channel_id = await asyncio.to_thread(db.get_storage_channel, user_id)
+    if not channel_id:
+        return
+    try:
+        copied = await context.bot.copy_message(
+            chat_id=channel_id,
+            from_chat_id=source_chat_id,
+            message_id=source_message_id,
+        )
+        tag = f"#{category_name.replace(' ', '_')}"
+        meta = (
+            f"{tag}\nSaved at: {datetime.utcnow().isoformat(timespec='seconds')}\n"
+            f"User: {user_id}"
+        )
+        await context.bot.send_message(chat_id=channel_id, text=meta)
+        await asyncio.to_thread(
+            db.attach_forward_copy,
+            message_db_id,
+            copied.chat_id,
+            copied.message_id,
+        )
+    except TelegramError as exc:
+        logger.warning(ASYNC_COPY_WARNING, user_id, exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects-implemented/telegram-categorizer-bot/requirements.txt
+++ b/projects-implemented/telegram-categorizer-bot/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot==21.6
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add a configurable, entirely client-side C-Test generator (`projects-implemented/ctest-interactive`) delivering the interactive workflow requested in open-source-ideas/ideas#174
- add a Telegram categorizer bot implementation (`projects-implemented/telegram-categorizer-bot`) with menu shortcuts, inline prompts, and documentation as described in open-source-ideas/ideas#269
- document the new implementations in the README so other contributors can find and reuse them easily

## Testing
- ctest-interactive: opened `index.html`, toggled settings, generated tests from sample and custom text, verified hints, scoring, and answer reveal
- telegram-categorizer-bot: ran `python -m bot`, exercised `/menu` buttons (add/set/list/current/link/help), created categories via inline UI, saved forwarded messages, and confirmed channel copy behaviour
